### PR TITLE
Get field token instead of full entity

### DIFF
--- a/src/Listener/UsersListener.php
+++ b/src/Listener/UsersListener.php
@@ -40,7 +40,7 @@ class UsersListener extends BaseListener
         }
 
         $table = TableRegistry::get($this->_controller()->modelClass);
-        $token = $table->tokenize($event->subject->entity->id);
+        $token = $table->tokenize($event->subject->entity->id)->token;
 
         Queue::push(['\App\Job\MailerJob', 'execute'], [
             'action' => 'forgotPassword',


### PR DESCRIPTION
src/Mailer/UserMailer.php expects $token to be string. Current solution passes full token entity which breaks functionality.